### PR TITLE
close serial port in case of error

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
-black
 ruff
 mypy
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,22 @@
-[tool.black]
-exclude = '''
-/(
-    \.git
-    | \.caches
-    | \.tox
-    | venv
-    | _build
-    | build
-    | dist
-
-)/
-'''
-line-length = 120
-
 [tool.ruff]
-# see https://beta.ruff.rs/docs/rules/
-select = ["B", "C90", "E", "F", "N", "PT", "W", "Q", "UP", "I"]
-ignore = ["E501"]  # black has power over line-lenght
+line-length = 120
 cache-dir = ".caches/.ruff"
 
-[tool.ruff.mccabe]
+[tool.ruff.format]
+# behave like Black
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint]
+# see https://beta.ruff.rs/docs/rules/
+select = ["B", "C90", "E", "F", "N", "PT", "W", "Q", "UP", "I"]
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["conrad_relaycard"]
 
 [tool.mypy]

--- a/src/conrad_relaycard/__init__.py
+++ b/src/conrad_relaycard/__init__.py
@@ -1,0 +1,3 @@
+from .card import RelayCard as RelayCard
+from .exceptions import RelayCardError as RelayCardError
+from .state import RelayState as RelayState

--- a/src/conrad_relaycard/__init__.py
+++ b/src/conrad_relaycard/__init__.py
@@ -1,3 +1,3 @@
-from .card import RelayCard as RelayCard
-from .exceptions import RelayCardError as RelayCardError
-from .state import RelayState as RelayState
+from .card import RelayCard  # noqa: F401
+from .exceptions import RelayCardError  # noqa: F401
+from .state import RelayState  # noqa: F401

--- a/src/conrad_relaycard/card.py
+++ b/src/conrad_relaycard/card.py
@@ -36,6 +36,7 @@ class RelayCard:
             )
 
         if not self._serial_port.is_open:
+            self._serial_port.close()
             raise RelayCardError(f"Port {self._serial_port.port} could not be opened")
 
         self._serial_port.reset_input_buffer()

--- a/src/conrad_relaycard/card.py
+++ b/src/conrad_relaycard/card.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from contextlib import suppress
 
 import serial
 
@@ -20,6 +21,10 @@ class RelayCard:
     def is_initialized(self) -> bool:
         return self.card_count > 0
 
+    def _try_close(self) -> None:
+        with suppress(Exception):
+            self._serial_port.close()
+
     def _get_serial_port(self, port: str | None = None) -> serial.Serial:
         if not hasattr(self, "_serial_port"):
             logging.debug(f"Opening serial port {port or self.port}")
@@ -36,7 +41,7 @@ class RelayCard:
             )
 
         if not self._serial_port.is_open:
-            self._serial_port.close()
+            self._try_close()
             raise RelayCardError(f"Port {self._serial_port.port} could not be opened")
 
         self._serial_port.reset_input_buffer()
@@ -46,6 +51,7 @@ class RelayCard:
 
     def _execute(self, command: CommandCodes, address: int, data: int) -> ResponseFrame:
         if not (0 < address <= self.card_count):
+            self._try_close()
             raise RelayCardError(f"Wrong relay address {address}. Expected 1-{self.card_count}")
 
         return self._send_frame(RequestFrame(command, address, data))
@@ -70,6 +76,7 @@ class RelayCard:
             # this is skipped if break called
             if error_log is None:
                 error_log = f"Wrong response value {response}. Expected {com_codes.response_code.name}"
+            self._try_close()
             logging.error(f"Error, retry #{_i}: {error_log}")
             raise RelayCardError(f"Retry #{_i}: {error_log}")
         return response
@@ -77,6 +84,7 @@ class RelayCard:
     def _send_frame(self, frame: RequestFrame) -> ResponseFrame:
         logging.info(f"Sending frame: {frame}")
         if not self.is_initialized:
+            self._try_close()
             raise RelayCardError("Initialize serial connection before sending")
 
         ser = self._get_serial_port()
@@ -85,6 +93,7 @@ class RelayCard:
         logging.debug(f"Sending bytes: {repr(out_bytes)}")
 
         if ser.write(out_bytes) != 4:
+            self._try_close()
             raise RelayCardError(f"Wrong length of send bytes: {out_bytes}. Expected 4")
 
         in_bytes = ser.read(4)

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -2,9 +2,7 @@ from unittest import mock
 
 import pytest
 
-from conrad_relaycard import RelayCard
-from conrad_relaycard import RelayCardError
-from conrad_relaycard import RelayState
+from conrad_relaycard import RelayCard, RelayCardError, RelayState
 
 
 def test_relaycard() -> None:

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -2,9 +2,9 @@ from unittest import mock
 
 import pytest
 
-from conrad_relaycard.card import RelayCard
-from conrad_relaycard.exceptions import RelayCardError
-from conrad_relaycard.state import RelayState
+from conrad_relaycard import RelayCard
+from conrad_relaycard import RelayCardError
+from conrad_relaycard import RelayState
 
 
 def test_relaycard():

--- a/tests/test_card.py
+++ b/tests/test_card.py
@@ -7,7 +7,7 @@ from conrad_relaycard import RelayCardError
 from conrad_relaycard import RelayState
 
 
-def test_relaycard():
+def test_relaycard() -> None:
     with mock.patch("serial.Serial") as mock_serial:
         mock_serial_instance = mock_serial.return_value
         mock_serial_instance.is_open = True
@@ -26,26 +26,26 @@ def test_relaycard():
         assert rly.is_initialized is True
         assert rly.card_count == 255
 
-        mock_serial_instance.read.return_value = b"\xFD\x00\x00\xFD"
+        mock_serial_instance.read.return_value = b"\xfd\x00\x00\xfd"
         assert rly.get_port(1, 0) is False
         assert rly.get_ports(1).to_byte() == RelayState(0).to_byte()
 
-        mock_serial_instance.read.return_value = b"\xFD\x00\x01\xFC"
+        mock_serial_instance.read.return_value = b"\xfd\x00\x01\xfc"
         assert rly.get_port(1, 0) is True
         assert rly.get_ports(1).to_byte() == RelayState(1).to_byte()
 
-        mock_serial_instance.read.return_value = b"\xF9\x00\x00\xF9"
+        mock_serial_instance.read.return_value = b"\xf9\x00\x00\xf9"
         assert rly.set_port(1, 0, True).to_byte() == RelayState(0).to_byte()
 
-        mock_serial_instance.read.return_value = b"\xFC\x00\x00\xFC"
+        mock_serial_instance.read.return_value = b"\xfc\x00\x00\xfc"
         assert rly.set_ports(1, RelayState(0)).to_byte() == RelayState(0).to_byte()
 
-        mock_serial_instance.read.return_value = b"\xF7\x00\x00\xF7"
+        mock_serial_instance.read.return_value = b"\xf7\x00\x00\xf7"
         assert rly.toggle_port(1, 0).to_byte() == RelayState(0).to_byte()
         assert rly.toggle_ports(1, RelayState(0)).to_byte() == RelayState(0).to_byte()
 
 
-def test_relaycard_error():
+def test_relaycard_error() -> None:
     with mock.patch("serial.Serial") as mock_serial:
         mock_serial_instance = mock_serial.return_value
         mock_serial_instance.is_open = False
@@ -64,7 +64,7 @@ def test_relaycard_error():
 
         with pytest.raises(RelayCardError, match="Wrong relay address 2000"):
             rly.get_port(2000, 0)
-        mock_serial_instance.read.return_value = b"\xFD\x00\x00\xFD"
+        mock_serial_instance.read.return_value = b"\xfd\x00\x00\xfd"
         with pytest.raises(RelayCardError, match="Wrong relay port 2000"):
             rly.get_port(1, 2000)
         with pytest.raises(RelayCardError, match="Wrong relay address 2000"):
@@ -95,7 +95,7 @@ def test_relaycard_error():
             rly.get_port(1, 0)
 
 
-def test_relaycard_internal():
+def test_relaycard_internal() -> None:
     with mock.patch("serial.Serial") as mock_serial:
         mock_serial_instance = mock_serial.return_value
         mock_serial_instance.is_open = False

--- a/tox.ini
+++ b/tox.ini
@@ -19,14 +19,14 @@ commands =
 
 [testenv:check]
 deps =
-    black
     mypy
     ruff
+    setuptools
 skip_install = true
 commands =
     python setup.py check --strict --metadata
+    ruff format .
     ruff check .
-    black --check --diff .
     mypy --install-types --non-interactive .
 
 [testenv:report]

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
 skip_install = true
 commands =
     python setup.py check --strict --metadata
-    ruff format .
+    ruff format --diff .
     ruff check .
     mypy --install-types --non-interactive .
 


### PR DESCRIPTION
As user cannot access the inter serial instance, the driver has to close the port in case of error

Additional:
* [make main classes accessable directly by conrad_relaycard](https://github.com/stephrdev/conrad-relaycard/commit/ad47635e1d5c47a9f010172ac30825344b886c73)
* [remove black and use ruff format instead](https://github.com/stephrdev/conrad-relaycard/commit/b4094feb228cf866f233e6046190aaa25c55c153)